### PR TITLE
Add type to AbortError

### DIFF
--- a/src/dial-test.js
+++ b/src/dial-test.js
@@ -62,6 +62,7 @@ module.exports = (common) => {
         await socket
       } catch (err) {
         expect(err.code).to.eql(AbortError.code)
+        expect(err.type).to.eql(AbortError.type)
         return
       }
       expect.fail('Did not throw error with code ' + AbortError.code)
@@ -80,6 +81,7 @@ module.exports = (common) => {
         await socket
       } catch (err) {
         expect(err.code).to.eql(AbortError.code)
+        expect(err.type).to.eql(AbortError.type)
         return
       } finally {
         connector.restore()

--- a/src/errors.js
+++ b/src/errors.js
@@ -4,10 +4,15 @@ class AbortError extends Error {
   constructor () {
     super('AbortError')
     this.code = AbortError.code
+    this.type = AbortError.type
   }
 
   static get code () {
     return 'ABORT_ERR'
+  }
+
+  static get type () {
+    return 'aborted'
   }
 }
 


### PR DESCRIPTION
AbortError should have a `type` field with the value 'aborted' as discussed in https://github.com/libp2p/interface-transport/pull/44#issuecomment-484431516