### PR TITLE
feat: make listen take an array of addrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A valid transport (one that follows the interface defined) must implement the fo
     - event: 'close'
     - event: 'connection'
     - event: 'error'
-    - `<Promise> listener.listen(multiaddr)`
+    - `<Promise> listener.listen(Array<multiaddr>)`
     - `listener.getAddrs()`
     - `<Promise> listener.close([options])`
 
@@ -168,11 +168,11 @@ The listener object created may emit the following events:
 
 ### Start a listener
 
-- `JavaScript` - `await listener.listen(multiaddr)`
+- `JavaScript` - `await listener.listen(Array<multiaddr>)`
 
 This method puts the listener in `listening` mode, waiting for incoming connections.
 
-`multiaddr` is the address that the listener should bind to.
+`Array<multiaddr>` is an array of the addresses that the listener should bind to.
 
 ### Get listener addrs
 

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
   },
   "homepage": "https://github.com/libp2p/interface-transport",
   "devDependencies": {
-    "aegir": "^17.0.1",
-    "dirty-chai": "^2.0.1"
+    "aegir": "^18.2.2"
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
     "async-iterator-to-pull-stream": "^1.3.0",
     "chai": "^4.2.0",
+    "dirty-chai": "^2.0.1",
     "interface-connection": "~0.3.3",
     "it-goodbye": "^2.0.0",
     "it-pipe": "^1.0.0",
-    "multiaddr": "^5.0.2",
+    "multiaddr": "^6.0.6",
     "pull-stream": "^3.6.9",
     "streaming-iterables": "^4.0.2"
   },

--- a/src/errors.js
+++ b/src/errors.js
@@ -13,7 +13,7 @@ class AbortError extends Error {
 
 class AllListenersFailedError extends Error {
   constructor () {
-    super('AllListenersFailedError')
+    super('All listeners failed to listen on any addresses, please verify the addresses you provided are correct')
     this.code = AllListenersFailedError.code
   }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -11,6 +11,18 @@ class AbortError extends Error {
   }
 }
 
+class AllListenersFailedError extends Error {
+  constructor () {
+    super('AllListenersFailedError')
+    this.code = AllListenersFailedError.code
+  }
+
+  static get code () {
+    return 'ERR_ALL_LISTENERS_FAILED'
+  }
+}
+
 module.exports = {
-  AbortError
+  AbortError,
+  AllListenersFailedError
 }

--- a/src/listen-test.js
+++ b/src/listen-test.js
@@ -8,6 +8,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 const pipe = require('it-pipe')
+const { collect } = require('streaming-iterables')
 
 module.exports = (common) => {
   describe('listen', () => {
@@ -22,7 +23,31 @@ module.exports = (common) => {
 
     it('simple', async () => {
       const listener = transport.createListener((conn) => {})
-      await listener.listen(addrs[0])
+      await listener.listen([addrs[0]])
+      await listener.close()
+    })
+
+    it('listen on multiple addresses', async () => {
+      // create an echo listener
+      const listener = transport.createListener((conn) => pipe(conn, conn))
+      await listener.listen(addrs.slice(0, 2))
+
+      // Connect on both addresses
+      const [socket1, socket2] = await Promise.all([
+        transport.dial(addrs[0]),
+        transport.dial(addrs[1])
+      ])
+
+      const data = Buffer.from('hi there')
+      const results = await pipe(
+        [data], // [data] -> socket1
+        socket1, // socket1 -> server (echo) -> socket1 -> socket2
+        socket2, // socket2 -> server (echo) -> socket2 -> collect
+        collect
+      )
+
+      expect(results).to.eql([data])
+
       await listener.close()
     })
 
@@ -35,7 +60,7 @@ module.exports = (common) => {
       const listener = transport.createListener((conn) => pipe(conn, conn))
 
       // Listen
-      await listener.listen(addrs[0])
+      await listener.listen([addrs[0]])
 
       // Create two connections to the listener
       const socket1 = await transport.dial(addrs[0])
@@ -66,7 +91,7 @@ module.exports = (common) => {
         })
 
         ;(async () => {
-          await listener.listen(addrs[0])
+          await listener.listen([addrs[0]])
           await transport.dial(addrs[0])
         })()
       })
@@ -95,7 +120,7 @@ module.exports = (common) => {
         listener.on('close', done)
 
         ;(async () => {
-          await listener.listen(addrs[0])
+          await listener.listen([addrs[0]])
           await listener.close()
         })()
       })


### PR DESCRIPTION
This changes `listener.listen` to take an array of multiaddrs.

Implements https://github.com/libp2p/interface-transport/issues/41