### PR TITLE
feat: timeline and close checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A valid transport (one that follows the interface defined) must implement the fo
 - type: `Transport`
   - `new Transport({ upgrader, ...[options] })`
   - `<Promise> transport.dial(multiaddr, [options])`
+  - `<Multiaddr[]> transport.filter(multiaddrs)`
   - `transport.createListener([options], handlerFunction)`
   - type: `transport.Listener`
     - event: 'listening'
@@ -176,6 +177,15 @@ try {
   controller.abort()
 // ----
 ```
+
+### Filtering Addresses
+
+- `JavaScript` - `const supportedAddrs = await transport.filter(multiaddrs)`
+
+When using a transport its important to be able to filter out `multiaddr`s that the transport doesn't support. A transport instance provides a filter method to return only the valid addresses it supports.
+
+`multiaddrs` must be an array of type [`multiaddr`](https://www.npmjs.com/multiaddr).
+Filter returns an array of `multiaddr`.
 
 ### Create a listener
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,13 @@ The `Upgrader` methods take a [MultiaddrConnection](#multiaddrconnection) and wi
 - `MultiaddrConnection`
   - `sink<function(source)>`: A [streaming iterable sink](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#sink-it)
   - `source<AsyncIterator>`: A [streaming iterable source](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#source-it)
+  - `close<function(Error)>`: A method for closing the connection
   - `conn`: The raw connection of the transport, such as a TCP socket.
   - `remoteAddr<Multiaddr>`: The remote `Multiaddr` of the connection.
+  - `[localAddr<Multiaddr>]`: An optional local `Multiaddr` of the connection.
+  - `timeline<object>`: A hash map of connection time events
+    - `open<number>`: The time in ticks the connection was opened
+    - `close<number>`: The time in ticks the connection was closed
 
 ### Creating a transport instance
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Publishing a test suite as a module lets multiple modules all ensure compatibili
 
 The purpose of this interface is not to reinvent any wheels when it comes to dialing and listening to transports. Instead, it tries to provide a uniform API for several transports through a shimmed interface.
 
-The API is presented with both Node.js and Go primitives, however there are no actual limitations for it to be extended for any other language, pushing forward the cross compatibility and interop through diferent stacks.
-
 ## Lead Maintainer
 
 [Jacob Heun](https://github.com/jacobheun/)
@@ -133,7 +131,7 @@ The `Upgrader` methods take a [MultiaddrConnection](#multiaddrconnection) and wi
 
 ### Creating a transport instance
 
-- `JavaScript` - `const transport = new Transport({ upgrader, ...[options] })`
+- `const transport = new Transport({ upgrader, ...[options] })`
 
 Creates a new Transport instance. `options` is an JavaScript object that should include the necessary parameters for the transport instance. Options **MUST** include an `Upgrader` instance, as Transports will use this to return `interface-connection` instances from `transport.dial` and the listener `handlerFunction`.
 
@@ -141,7 +139,7 @@ Creates a new Transport instance. `options` is an JavaScript object that should 
 
 ### Dial to another peer
 
-- `JavaScript` - `const connection = await transport.dial(multiaddr, [options])`
+- `const connection = await transport.dial(multiaddr, [options])`
 
 This method uses a transport to dial a Peer listening on `multiaddr`.
 
@@ -180,7 +178,7 @@ try {
 
 ### Filtering Addresses
 
-- `JavaScript` - `const supportedAddrs = await transport.filter(multiaddrs)`
+- `const supportedAddrs = await transport.filter(multiaddrs)`
 
 When using a transport its important to be able to filter out `multiaddr`s that the transport doesn't support. A transport instance provides a filter method to return only the valid addresses it supports.
 
@@ -189,7 +187,7 @@ Filter returns an array of `multiaddr`.
 
 ### Create a listener
 
-- `JavaScript` - `const listener = transport.createListener([options], handlerFunction)`
+- `const listener = transport.createListener([options], handlerFunction)`
 
 This method creates a listener on the transport. Implementations **MUST** call `upgrader.upgradeInbound(multiaddrConnection)` and pass its results to the `handlerFunction` and any emitted `connection` events.
 
@@ -206,7 +204,7 @@ The listener object created may emit the following events:
 
 ### Start a listener
 
-- `JavaScript` - `await listener.listen(multiaddr)`
+- `await listener.listen(multiaddr)`
 
 This method puts the listener in `listening` mode, waiting for incoming connections.
 
@@ -214,13 +212,13 @@ This method puts the listener in `listening` mode, waiting for incoming connecti
 
 ### Get listener addrs
 
-- `JavaScript` - `listener.getAddrs()`
+- `listener.getAddrs()`
 
 This method returns the addresses on which this listener is listening. Useful when listening on port 0 or any interface (0.0.0.0).
 
 ### Stop a listener
 
-- `JavaScript` - `await listener.close([options])`
+- `await listener.close([options])`
 
 This method closes the listener so that no more connections can be opened on this transport instance.
 

--- a/src/dial-test.js
+++ b/src/dial-test.js
@@ -16,21 +16,18 @@ const sinon = require('sinon')
 
 module.exports = (common) => {
   const upgrader = {
-    upgradeOutbound (multiaddrConnection) {
-      ['sink', 'source', 'remoteAddr', 'conn', 'timeline'].forEach(prop => {
+    _upgrade (multiaddrConnection) {
+      ['sink', 'source', 'remoteAddr', 'conn', 'timeline', 'close'].forEach(prop => {
         expect(multiaddrConnection).to.have.property(prop)
       })
       expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)
-
-      return { sink: multiaddrConnection.sink, source: multiaddrConnection.source }
+      return multiaddrConnection
+    },
+    upgradeOutbound (multiaddrConnection) {
+      return upgrader._upgrade(multiaddrConnection)
     },
     upgradeInbound (multiaddrConnection) {
-      ['sink', 'source', 'remoteAddr', 'conn', 'timeline'].forEach(prop => {
-        expect(multiaddrConnection).to.have.property(prop)
-      })
-      expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)
-
-      return { sink: multiaddrConnection.sink, source: multiaddrConnection.source }
+      return upgrader._upgrade(multiaddrConnection)
     }
   }
 
@@ -68,6 +65,16 @@ module.exports = (common) => {
       expect(upgradeSpy.returned(conn)).to.equal(true)
       expect(result.length).to.equal(1)
       expect(result[0].toString()).to.equal('hey')
+    })
+
+    it('can close connections', async () => {
+      const upgradeSpy = sinon.spy(upgrader, 'upgradeOutbound')
+      const conn = await transport.dial(addrs[0])
+
+      expect(upgradeSpy.callCount).to.equal(1)
+      expect(upgradeSpy.returned(conn)).to.equal(true)
+      await conn.close()
+      expect(isValidTick(conn.timeline.close)).to.equal(true)
     })
 
     it('to non existent listener', async () => {

--- a/src/dial-test.js
+++ b/src/dial-test.js
@@ -6,6 +6,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
+const { isValidTick } = require('./utils')
 const goodbye = require('it-goodbye')
 const { collect } = require('streaming-iterables')
 const pipe = require('it-pipe')
@@ -16,16 +17,18 @@ const sinon = require('sinon')
 module.exports = (common) => {
   const upgrader = {
     upgradeOutbound (multiaddrConnection) {
-      ['sink', 'source', 'remoteAddr', 'conn'].forEach(prop => {
+      ['sink', 'source', 'remoteAddr', 'conn', 'timeline'].forEach(prop => {
         expect(multiaddrConnection).to.have.property(prop)
       })
+      expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)
 
       return { sink: multiaddrConnection.sink, source: multiaddrConnection.source }
     },
     upgradeInbound (multiaddrConnection) {
-      ['sink', 'source', 'remoteAddr', 'conn'].forEach(prop => {
+      ['sink', 'source', 'remoteAddr', 'conn', 'timeline'].forEach(prop => {
         expect(multiaddrConnection).to.have.property(prop)
       })
+      expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)
 
       return { sink: multiaddrConnection.sink, source: multiaddrConnection.source }
     }

--- a/src/filter-test.js
+++ b/src/filter-test.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+module.exports = (common) => {
+  const upgrader = {
+    _upgrade (multiaddrConnection) {
+      return multiaddrConnection
+    },
+    upgradeOutbound (multiaddrConnection) {
+      return upgrader._upgrade(multiaddrConnection)
+    },
+    upgradeInbound (multiaddrConnection) {
+      return upgrader._upgrade(multiaddrConnection)
+    }
+  }
+
+  describe('filter', () => {
+    let addrs
+    let transport
+
+    before(async () => {
+      ({ addrs, transport } = await common.setup({ upgrader }))
+    })
+
+    after(() => common.teardown && common.teardown())
+
+    it('filters addresses', () => {
+      const filteredAddrs = transport.filter(addrs)
+      expect(filteredAddrs).to.eql(addrs)
+    })
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@
 
 const dial = require('./dial-test')
 const listen = require('./listen-test')
+const filter = require('./filter-test')
 
 module.exports = (common) => {
   describe('interface-transport', () => {
     dial(common)
     listen(common)
+    filter(common)
   })
 }
 

--- a/src/listen-test.js
+++ b/src/listen-test.js
@@ -9,20 +9,23 @@ chai.use(dirtyChai)
 const sinon = require('sinon')
 
 const pipe = require('it-pipe')
+const { isValidTick } = require('./utils')
 
 module.exports = (common) => {
   const upgrader = {
     upgradeOutbound (multiaddrConnection) {
-      ['sink', 'source', 'remoteAddr', 'conn'].forEach(prop => {
+      ['sink', 'source', 'remoteAddr', 'conn', 'timeline'].forEach(prop => {
         expect(multiaddrConnection).to.have.property(prop)
       })
+      expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)
 
       return { sink: multiaddrConnection.sink, source: multiaddrConnection.source }
     },
     upgradeInbound (multiaddrConnection) {
-      ['sink', 'source', 'remoteAddr', 'conn'].forEach(prop => {
+      ['sink', 'source', 'remoteAddr', 'conn', 'timeline'].forEach(prop => {
         expect(multiaddrConnection).to.have.property(prop)
       })
+      expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)
 
       return { sink: multiaddrConnection.sink, source: multiaddrConnection.source }
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  /**
+   * A tick is considered valid if it happened between now
+   * and `ms` milliseconds ago
+   * @param {number} date Time in ticks
+   * @param {number} ms max milliseconds that should have expired
+   * @returns {boolean}
+   */
+  isValidTick: function isValidTick (date, ms = 5000) {
+    const now = Date.now()
+    if (date > now - ms && date <= now) return true
+    return false
+  }
+}


### PR DESCRIPTION
* Adds checking and docs for `timeline` (open and close)
* Adds checking and docs for `close` on the MultiaddrConnection
* Adds checking and docs for `filter`. It's been around, but hasn't been documented or tested
* Removes reference of the go implementation. This repo was originally intended to be used as an interface for both, but it's JS specific, let's treat it that way.

While this shouldn't technically be a breaking change for the latest minor version, it will very likely break tests, so we will do a minor version bump.